### PR TITLE
Always use https or http protocol

### DIFF
--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -38,7 +38,7 @@ exports.DEFAULT_CONFIG = {
   host: 'in.treasuredata.com',
   logging: true,
   pathname: '/js/v3/event/',
-  protocol: document.location.protocol,
+  protocol: document.location.protocol === 'https:' ? 'https:' : 'http:',
   requestType: 'jsonp'
 }
 


### PR DESCRIPTION
This is needed so people opening html files directly with `file://` can test their td-js-sdk code. 