### PR TITLE
Default to startTunnel to false for karma browserstack

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,7 +53,8 @@ module.exports = function (config) {
     autoWatch: false,
 
     browserStack: {
-      project: 'td-js-sdk'
+      project: 'td-js-sdk',
+      startTunnel: false
     },
 
     // define browsers

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "e2e-prepare": "selenium-standalone install",
     "e2e-server": "node ./bin/server.js",
     "test": "standard && node ./bin/test.js",
-    "test-full": "karma start",
+    "test-full": "karma start --browserStack.startTunnel true",
     "test-local": "karma start --browsers Chrome,Firefox,Safari --concurrency 3",
-    "test-ci": "karma start --browserStack.startTunnel 0 --browserStack.tunnelIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER"
+    "test-ci": "karma start --browserStack.tunnelIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Digging into why the tests are failing I noticed the browserstack plugin expects `false` but you can't pass it in through cli options.

See: https://github.com/karma-runner/karma-browserstack-launcher/blob/master/index.js#L28

Confirmed it fixes the other failing branch with: https://github.com/treasure-data/td-js-sdk/commits/cdp-segmentation-browserstack-issue