### PR TITLE
Guard against document.location being null

### DIFF
--- a/lib/plugins/track.js
+++ b/lib/plugins/track.js
@@ -50,8 +50,9 @@ function configureValues (track) {
       return getMeta('description')
     },
     td_url: function () {
-      if (!document.location || !document.location.href) return ''
-      return document.location.href.split('#')[0]
+      return (!document.location || !document.location.href)
+        ? ''
+        : document.location.href.split('#')[0]
     },
     td_user_agent: function () {
       return window.navigator.userAgent

--- a/lib/plugins/track.js
+++ b/lib/plugins/track.js
@@ -50,6 +50,7 @@ function configureValues (track) {
       return getMeta('description')
     },
     td_url: function () {
+      if (!document.location || !document.location.href) return ''
       return document.location.href.split('#')[0]
     },
     td_user_agent: function () {


### PR DESCRIPTION
No idea how this happens or how to test it. I went with returning an empty string to keep return type the same