### PR TITLE
Convert storage.expires into Date for IE8 compat

### DIFF
--- a/lib/plugins/track.js
+++ b/lib/plugins/track.js
@@ -189,11 +189,13 @@ exports.configure = function configure (config) {
       local: storage.domain === 'localhost',
       custom: storage.customDomain
     }
+    var expires = new Date()
+    expires.setSeconds(expires.getSeconds() + clone.expires)
 
     // When it's localhost, an IP, or custom domain, set the cookie directly
     if (is.ip || is.local || is.custom) {
       clone.domain = is.local ? null : clone.domain
-      cookie.setItem(storage.name, uuid, clone.expires, clone.path, clone.domain)
+      cookie.setItem(storage.name, uuid, expires, clone.path, clone.domain)
     } else {
       // Otherwise iterate recursively on the domain until it gets set
       // For example, if we have three sites:
@@ -211,7 +213,7 @@ exports.configure = function configure (config) {
       } else {
         for (; i < ll; i++) {
           clone.domain = domains[i]
-          cookie.setItem(storage.name, uuid, clone.expires, clone.path, clone.domain)
+          cookie.setItem(storage.name, uuid, expires, clone.path, clone.domain)
 
           // Break when cookies aren't being cleared and it gets set properly
           // Don't break when uuid is falsy so all the cookies get cleared

--- a/test/e2e/usersegment.spec.js
+++ b/test/e2e/usersegment.spec.js
@@ -2,36 +2,47 @@ var test = require('tape')
 
 module.exports = function (browser, initOpts, finish) {
   test('usersegment test', function (t) {
-    t.plan(1)
+    var count = 2
+    t.plan(2)
 
-    function initTest () {
-      browser.get('http://localhost:9999/fixtures/usersegment', getStatus)
+    function finished () {
+      count--
+      if (count === 0) {
+        browser.quit()
+        finish()
+      }
     }
 
-    function getStatus () {
-      browser.elementById('status', function (err, el) {
-        return err ? t.fail('Error', err) : el.text(getText)
+    function initTest () {
+      browser.get('http://localhost:9999/fixtures/usersegment', function () {
+        getStatus(0)
+        getStatus(1)
       })
     }
 
-    function getText (err, text) {
-      if (err) {
-        t.fail('Error', err)
-        browser.quit()
-        return finish()
+    function getStatus (num) {
+      browser.elementById('status' + num, function (err, el) {
+        return err ? t.fail('Error', err) : el.text(getText(num))
+      })
+    }
+
+    function getText (num) {
+      return function (err, text) {
+        if (err) {
+          t.fail('Error', err)
+          return finished()
+        }
+        switch (text) {
+          case 'success':
+            t.pass('status is success')
+            return finished()
+          case 'failure':
+            t.fail('status is failure')
+            return finished()
+          default:
+            return getStatus(num)
+        }
       }
-      switch (text) {
-        case 'success':
-          t.pass('status is success')
-          break
-        case 'failure':
-          t.fail('status is failure')
-          break
-        default:
-          return getStatus()
-      }
-      browser.quit()
-      finish()
     }
 
     browser.init(initOpts, initTest)

--- a/test/treasure.track.spec.js
+++ b/test/treasure.track.spec.js
@@ -156,22 +156,36 @@ describe('Treasure Tracker', function () {
         expect(treasure.client.storage).to.equal(false)
       })
 
-      it('should let you set expiration to 0', function () {
+      it('should let you set expires to 0', function () {
         configuration.storage = {
-          expiration: 0
+          expires: 0
         }
         treasure = new Treasure(configuration)
 
-        expect(treasure.client.storage.expiration).to.equal(0)
+        expect(treasure.client.storage.expires).to.equal(0)
       })
 
-      it('should let you set expiration to an integer', function () {
+      it('should let you set expires to an integer', function () {
         configuration.storage = {
-          expiration: 128
+          expires: 128
         }
         treasure = new Treasure(configuration)
 
-        expect(treasure.client.storage.expiration).to.equal(128)
+        expect(treasure.client.storage.expires).to.equal(128)
+      })
+
+      it('should set a cookie with the desired expires', function (done) {
+        configuration.storage = {
+          expires: 1
+        }
+        treasure = new Treasure(configuration)
+
+        expect(treasure.getCookie('_td')).to.be.ok()
+
+        setTimeout(function () {
+          expect(treasure.getCookie('_td')).to.not.be.ok()
+          done()
+        }, 1500) // 1500ms is longer than 1s
       })
 
       it('should remember your previous clientId', function () {


### PR DESCRIPTION
IE 8 doesn't support `max-age` on cookies. For more info see: https://mrcoles.com/blog/cookies-max-age-vs-expires/

By default our cookies lib uses `max-age` if the value passed to it is a number, so we need to convert it into a Date.

This assumes `storage.expires` is a number, but that's what it says in the README.