### PR TITLE
Update js sdk process

### DIFF
--- a/bin/activate-version.sh
+++ b/bin/activate-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+DRYRUN=''
+VERSION=''
+TO_VERSION=''
+WAIT=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -d)
+      DRYRUN="--dryrun"
+      ;;
+    --version=*)
+      VERSION="${1#*=}"
+      ;;
+    --to-version=*)
+      TO_VERSION="${1#*=}"
+      ;;
+    --wait)
+      WAIT=1
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n"
+      printf "***************************\n"
+      exit 1
+  esac
+  shift
+done
+
+set -euo pipefail
+
+if [ "$VERSION" = '' ]; then
+  printf "Must specify VERSION"
+  exit 1
+fi
+
+if [ "$TO_VERSION" = '' ]; then
+  printf "Must specify TO_VERSION"
+  exit 1
+fi
+
+aws --profile dev-frontend                      \
+  s3 sync "s3://td-cdn-experiment/sdk/${VERSION}/" "s3://td-cdn-experiment/sdk/${TO_VERSION}/" \
+    ${DRYRUN}                                   \
+    --region 'us-east-2'                        \
+    --acl 'public-read'                         \
+    --cache-control 'public, max-age=315360000' \
+    --exclude "*loader.min.js"
+
+if [ "$DRYRUN" != '' ]; then
+  exit 0
+fi
+
+if [ $WAIT -eq 1 ]; then
+  ./bin/invalidate-release.sh --version=${TO_VERSION} --wait
+else
+  ./bin/invalidate-release.sh --version=${TO_VERSION}
+fi

--- a/bin/activate-version.sh
+++ b/bin/activate-version.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
 DRYRUN='--dryrun'
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-VERSION=$(jq -r '.version' < "${ROOT_DIR}/package.json")
-TO_VERSION=$(echo $VERSION | sed 's/\.[0-9]*$//g')
+VERSION=''
 WAIT=0
 while [ $# -gt 0 ]; do
   case "$1" in
     -f|--force)
       DRYRUN=""
+      ;;
+    --version=*)
+      VERSION="${1#*=}"
       ;;
     --wait)
       WAIT=1
@@ -21,6 +22,13 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$VERSION" = "" ]; then
+  echo "You must supply a --version"
+  exit 1
+fi
+
+TO_VERSION=$(echo $VERSION | sed 's/\.[0-9]*$//g')
 
 set -euo pipefail
 

--- a/bin/activate-version.sh
+++ b/bin/activate-version.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
 
-DRYRUN=''
-VERSION=''
-TO_VERSION=''
+DRYRUN='--dryrun'
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+VERSION=$(jq -r '.version' < "${ROOT_DIR}/package.json")
+TO_VERSION=$(echo $VERSION | sed 's/\.[0-9]*$//g')
 WAIT=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    -d)
-      DRYRUN="--dryrun"
-      ;;
-    --version=*)
-      VERSION="${1#*=}"
-      ;;
-    --to-version=*)
-      TO_VERSION="${1#*=}"
+    -f|--force)
+      DRYRUN=""
       ;;
     --wait)
       WAIT=1
@@ -28,16 +23,6 @@ while [ $# -gt 0 ]; do
 done
 
 set -euo pipefail
-
-if [ "$VERSION" = '' ]; then
-  printf "Must specify VERSION"
-  exit 1
-fi
-
-if [ "$TO_VERSION" = '' ]; then
-  printf "Must specify TO_VERSION"
-  exit 1
-fi
 
 aws --profile dev-frontend                      \
   s3 sync "s3://td-cdn-experiment/sdk/${VERSION}/" "s3://td-cdn-experiment/sdk/${TO_VERSION}/" \

--- a/bin/check-invalidation.sh
+++ b/bin/check-invalidation.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+ID=''
+DRYRUN=''
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -d)
+      DRYRUN="--dryrun"
+      ;;
+    --id=*)
+      ID="${1#*=}"
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n"
+      printf "***************************\n"
+      exit 1
+  esac
+  shift
+done
+
+while [ $(aws --profile dev-frontend     \
+  cloudfront get-invalidation         \
+    --distribution-id E1F7ECRVBF3EX2  \
+    --id ${ID}                        \
+    ${DRYRUN}                         \
+    --region 'us-east-2' | jq -r '.Invalidation.Status') = "InProgress" ]; do
+      printf '.'
+      sleep 4
+    done
+
+echo Invalidation $(aws --profile dev-frontend     \
+  cloudfront get-invalidation         \
+    --distribution-id E1F7ECRVBF3EX2  \
+    --id ${ID}                        \
+    ${DRYRUN}                         \
+    --region 'us-east-2' | jq -r '.Invalidation.Status')

--- a/bin/check-invalidation.sh
+++ b/bin/check-invalidation.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 ID=''
-DRYRUN=''
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    -d)
-      DRYRUN="--dryrun"
-      ;;
     --id=*)
       ID="${1#*=}"
       ;;
@@ -26,7 +21,6 @@ while [ $(aws --profile dev-frontend     \
   cloudfront get-invalidation         \
     --distribution-id E1F7ECRVBF3EX2  \
     --id ${ID}                        \
-    ${DRYRUN}                         \
     --region 'us-east-2' | jq -r '.Invalidation.Status') = "InProgress" ]; do
       printf '.'
       sleep 4
@@ -36,5 +30,4 @@ echo Invalidation $(aws --profile dev-frontend     \
   cloudfront get-invalidation         \
     --distribution-id E1F7ECRVBF3EX2  \
     --id ${ID}                        \
-    ${DRYRUN}                         \
     --region 'us-east-2' | jq -r '.Invalidation.Status')

--- a/bin/invalidate-release.sh
+++ b/bin/invalidate-release.sh
@@ -3,13 +3,13 @@
 set -euo pipefail
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 VERSION=$(jq -r '.version' < "${ROOT_DIR}/package.json")
-DRYRUN=''
+DRYRUN='--dryrun'
 WAIT=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    -d)
-      DRYRUN="--dryrun"
+    -f|--force)
+      DRYRUN=""
       ;;
     --version=*)
       VERSION="${1#*=}"

--- a/bin/invalidate-release.sh
+++ b/bin/invalidate-release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+VERSION=$(jq -r '.version' < "${ROOT_DIR}/package.json")
+DRYRUN=''
+WAIT=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -d)
+      DRYRUN="--dryrun"
+      ;;
+    --version=*)
+      VERSION="${1#*=}"
+      ;;
+    --wait)
+      WAIT=1
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n"
+      printf "***************************\n"
+      exit 1
+  esac
+  shift
+done
+
+JSON=$(aws --profile dev-frontend                            \
+  cloudfront create-invalidation                             \
+    --distribution-id E1F7ECRVBF3EX2                         \
+    --paths /sdk/${VERSION}/td.js /sdk/${VERSION}/td.min.js  \
+    ${DRYRUN}                                                \
+    --region 'us-east-2')
+
+INVALIDATION_ID=$(echo $JSON | jq -r '.Invalidation.Id')
+echo Created Invalidation: $INVALIDATION_ID
+
+if [ $WAIT -eq 1 ]; then
+  echo "Waiting until invalidation complete"
+  ./bin/check-invalidation.sh --id=$INVALIDATION_ID
+fi

--- a/bin/upload-version.sh
+++ b/bin/upload-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+DRYRUN=''
+if [ "$1" = '-d' ]; then
+  DRYRUN='--dryrun'
+fi
+
+set -euo pipefail
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+VERSION=$(jq -r '.version' < "${ROOT_DIR}/package.json")
+
+aws --profile dev-frontend                      \
+  s3 sync ./dist/ "s3://td-cdn-experiment/sdk/${VERSION}/" \
+    ${DRYRUN}                                   \
+    --region 'us-east-2'                        \
+    --acl 'public-read'                         \
+    --cache-control 'public, max-age=315360000' \
+    --exclude "*loader.min.js"

--- a/bin/upload-version.sh
+++ b/bin/upload-version.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-DRYRUN=''
-if [ "$1" = '-d' ]; then
-  DRYRUN='--dryrun'
+DRYRUN='--dryrun'
+if [ "$1" = '-f' | "$1" = '--force' ]; then
+  DRYRUN=''
 fi
 
 set -euo pipefail


### PR DESCRIPTION
An update to our upload scripts

```
# upload current version in package.json to a folder on S3
./bin/upload-version.sh
# sync version already on S3 to a release folder, automatically make Cloudfront invalidation
./bin/activate-version.sh --version=X.Y.Z --to-version=A.B
# same as above, just wait until invalidation completes
./bin/activate-version.sh --version=X.Y.Z --to-version=A.B --wait
# check on an invalidation in progress
./bin/check-invalidation.sh --id=<CLOUDFRONT_INVALIDATION_ID>
```