### PR TITLE
customizable table name on click events

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.development** : Boolean (optional) - triggers development mode which causes requests to be logged and not get sent. Default: `false`
 * **config.logging** : Boolean (optional) - enable or disable logging. Default: `true`
 * **config.globalIdCookie** : String (optional) - cookie td_globalid name. Default: `_td_global`
-* **config.clickTable** : String (optional) - name of the table to which the click event will be sent. Default: `clicks`
 
 **Track/Storage parameters:**
 
@@ -366,7 +365,7 @@ Setup an event listener to automatically log clicks.
 
 ```javascript
 var td = new Treasure({...})
-td.trackClicks()
+td.trackClicks({ tableName: 'custom_table_name' })
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.development** : Boolean (optional) - triggers development mode which causes requests to be logged and not get sent. Default: `false`
 * **config.logging** : Boolean (optional) - enable or disable logging. Default: `true`
 * **config.globalIdCookie** : String (optional) - cookie td_globalid name. Default: `_td_global`
-* **config.globalIdCookie** : String (optional) - name of the table to which the click event will be sent. Default: `clicks`
+* **config.clickTable** : String (optional) - name of the table to which the click event will be sent. Default: `clicks`
 
 **Track/Storage parameters:**
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.development** : Boolean (optional) - triggers development mode which causes requests to be logged and not get sent. Default: `false`
 * **config.logging** : Boolean (optional) - enable or disable logging. Default: `true`
 * **config.globalIdCookie** : String (optional) - cookie td_globalid name. Default: `_td_global`
+* **config.globalIdCookie** : String (optional) - name of the table to which the click event will be sent. Default: `clicks`
 
 **Track/Storage parameters:**
 

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -40,7 +40,8 @@ exports.DEFAULT_CONFIG = {
   host: '@HOST',
   logging: true,
   pathname: '@PATHNAME',
-  requestType: 'jsonp'
+  requestType: 'jsonp',
+  clickTable: 'clicks'
 }
 
 /**

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -40,8 +40,7 @@ exports.DEFAULT_CONFIG = {
   host: '@HOST',
   logging: true,
   pathname: '@PATHNAME',
-  requestType: 'jsonp',
-  clickTable: 'clicks'
+  requestType: 'jsonp'
 }
 
 /**

--- a/lib/plugins/clicks.js
+++ b/lib/plugins/clicks.js
@@ -18,7 +18,8 @@ function trackClicks (trackClicksOptions) {
   var options = assign({
     element: window.document,
     extendClickData: defaultExtendClickData,
-    ignoreAttribute: 'td-ignore'
+    ignoreAttribute: 'td-ignore',
+    tableName: 'clicks'
   }, trackClicksOptions)
 
   var treeHasIgnoreAttribute = elementUtils
@@ -42,7 +43,7 @@ function trackClicks (trackClicksOptions) {
       var elementData = elementUtils.getElementData(target)
       var data = options.extendClickData(e, elementData)
       if (data) {
-        instance.trackEvent(instance.client.clickTable, data)
+        instance.trackEvent(options.tableName, data)
       }
     }
   }

--- a/lib/plugins/clicks.js
+++ b/lib/plugins/clicks.js
@@ -41,9 +41,8 @@ function trackClicks (trackClicksOptions) {
     ) {
       var elementData = elementUtils.getElementData(target)
       var data = options.extendClickData(e, elementData)
-      var tableName = options.tableName || 'clicks'
       if (data) {
-        instance.trackEvent(tableName, data)
+        instance.trackEvent(instance.client.clickTable, data)
       }
     }
   }

--- a/lib/plugins/clicks.js
+++ b/lib/plugins/clicks.js
@@ -41,8 +41,9 @@ function trackClicks (trackClicksOptions) {
     ) {
       var elementData = elementUtils.getElementData(target)
       var data = options.extendClickData(e, elementData)
+      var tableName = options.tableName || 'clicks'
       if (data) {
-        instance.trackEvent('clicks', data)
+        instance.trackEvent(tableName, data)
       }
     }
   }


### PR DESCRIPTION
This PR becomes change the table to send the event

example
```js
var td = new Treasure()
td.trackClicks({ tableName: 'custom_table_name' })
```