### PR TITLE
Improve BrowserStack reporting

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
-// Karma configuration
-// Generated on Tue Oct 03 2017 21:21:19 GMT-0500 (CDT)
+var branch = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH
+var sha = require('child_process')
+  .execSync('git rev-parse --short=9 HEAD', { cwd: __dirname })
+  .toString().trim()
 
 module.exports = function (config) {
   config.set({
@@ -35,7 +37,7 @@ module.exports = function (config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['min'],
+    reporters: ['min', 'BrowserStack'],
 
     // web server port
     port: 9876,
@@ -51,7 +53,8 @@ module.exports = function (config) {
     autoWatch: false,
 
     browserStack: {
-      project: 'td-js-sdk',
+      project: branch === 'master' ? 'td-js-sdk' : 'td-js-sdk-dev',
+      build: sha,
       startTunnel: false
     },
 


### PR DESCRIPTION
1. Added BrowserStack reporter which should mark sessions as failed in BrowserStack when tests fail, so failures are easier to track down.
2. Added a build identifier of the current SHA, so builds are more easily identifiable.
3. Use a different project name for non-master builds. This should prevent PR builds from clobbering the BrowserStack build status linked in the README and in the TD Docs [Link here](https://www.browserstack.com/automate/public-build/ODRhSFV4NCtpdVRFTWpaMC9EU1FpdTVWaGd6Yk83VlppeHIxOTRzZFdJMD0tLStXZW1BVlEydEs3cC92blh5a2RFY1E9PQ==--a3bfa388c7f2ec3d859e819d4f6d3c20433aeaa9)