### PR TITLE
Build before tests run

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -74,13 +74,13 @@ cat $ROOT_DIR/src/loader.js |
 
 ESCAPED_LOADER="$(echo $ROOT_DIR/dist/loader.min.js | sed -e 's^/^\\/^g')"
 
-sed -i '' "/\!function.*/ {\
-  r $ROOT_DIR/dist/loader.min.js\
-  d\
-}" $ROOT_DIR/README.md
+sed -i '.backup' "/\!function.*/ {
+  r $ROOT_DIR/dist/loader.min.js
+  d
+}" $ROOT_DIR/README.md && rm $ROOT_DIR/README.md.backup
 
-sed -i '' 's_;</script>_;\
-</script>_' $ROOT_DIR/README.md
+sed -i '.backup' 's_;</script>_;\
+</script>_' $ROOT_DIR/README.md && rm $ROOT_DIR/README.md.backup
 
 if [ $FILENAME != "td" ]
 then

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -74,9 +74,9 @@ cat $ROOT_DIR/src/loader.js |
 
 ESCAPED_LOADER="$(echo $ROOT_DIR/dist/loader.min.js | sed -e 's^/^\\/^g')"
 
-sed -i '' "/\!function.*/ {
-  r $ROOT_DIR/dist/loader.min.js
-  d
+sed -i '' "/\!function.*/ {\
+  r $ROOT_DIR/dist/loader.min.js\
+  d\
 }" $ROOT_DIR/README.md
 
 sed -i '' 's_;</script>_;\

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,6 +9,15 @@ module.exports = function (config) {
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
 
+    // Allocating a browser can take pretty long (eg. if we are out of capacity and need to wait
+    // for another build to finish) and so the `captureTimeout` typically kills
+    // an in-queue-pending request, which makes no sense.
+    captureTimeout: 120000,
+
+    // Increase default browser timeout for when
+    // devices or emulators take a while to boot up
+    browserNoActivityTimeout: 120000,
+
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha'],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "e2e-prepare": "selenium-standalone install",
     "e2e-server": "node ./bin/server.js",
     "version": "npm run build && git add README.md dist/td.js dist/td.min.js",
+    "pretest": "npm run build",
     "test": "standard && node ./bin/test.js",
     "test-full": "karma start --browserStack.startTunnel true",
     "test-local":


### PR DESCRIPTION
Fixes the `Cannot resolve 'file' or 'directory' ./config` errors because config.js hasn't been generated