### PR TITLE
Update Safari on High Sierra to 11.1

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -113,7 +113,7 @@ module.exports = function (config) {
       bs_safari_11_mac: {
         base: 'BrowserStack',
         browser: 'safari',
-        browser_version: '11.0',
+        browser_version: '11.1',
         os: 'OS X',
         os_version: 'High Sierra'
       },


### PR DESCRIPTION
BrowserStack have changed the version they have available.