### PR TITLE
ITP 1.2 Compliance - server side cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.storage.domain** : String (optional) - cookie domain. Default: result of `document.location.hostname`
 
 **Server Side Cookie:**
-* **useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie - Default False
+* **config.useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie - Default False
 * **config.cookieDomain** : String | (String) => String (optional) - Domain against which the Server Side Cokkie is set Default: `window.location.hostname`
 * **config.cookieDomainHost** : String (optional) - hostname to request server side cookie from Default `ssc.${cookieDomain}`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install td-js-sdk on your page by copying the appropriate JavaScript snippet bel
 
 ```html
 <script type="text/javascript">
-!function(t,e){if(void 0===e[t]){e[t]=function(){e[t].clients.push(this),this._init=[Array.prototype.slice.call(arguments)]},e[t].clients=[];for(var r=function(t){return function(){return this["_"+t]=this["_"+t]||[],this["_"+t].push(Array.prototype.slice.call(arguments)),this}},s=["blockEvents","unblockEvents","setSignedMode","setAnonymousMode","resetUUID","addRecord","fetchGlobalID","set","trackEvent","trackPageview","trackClicks","ready"],n=0;n<s.length;n++){var c=s[n];e[t].prototype[c]=r(c)}var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.treasuredata.com/sdk/2.1/td.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(o,a)}}("Treasure",this);
+!function(t,e){if(void 0===e[t]){e[t]=function(){e[t].clients.push(this),this._init=[Array.prototype.slice.call(arguments)]},e[t].clients=[];for(var r=function(t){return function(){return this["_"+t]=this["_"+t]||[],this["_"+t].push(Array.prototype.slice.call(arguments)),this}},s=["blockEvents","unblockEvents","setSignedMode","setAnonymousMode","resetUUID","addRecord","fetchGlobalID","set","fetchServerCookie","trackEvent","trackPageview","trackClicks","ready"],n=0;n<s.length;n++){var c=s[n];e[t].prototype[c]=r(c)}var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.treasuredata.com/sdk/2.1/td.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(o,a)}}("Treasure",this);
 </script>
 ```
 
@@ -268,7 +268,7 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.logging** : Boolean (optional) - enable or disable logging. Default: `true`
 * **config.globalIdCookie** : String (optional) - cookie td_globalid name. Default: `_td_global`
 * **config.startInSignedMode** : Boolean (optional) - Tell the SDK to default to Signed Mode if no choice is already made. Default: `false`
-- **config.jsonpTimeout** : Number (optional) - JSONP timeout (in milliseconds) Default: `10000`
+* **config.jsonpTimeout** : Number (optional) - JSONP timeout (in milliseconds) Default: `10000`
 
 **Track/Storage parameters:**
 
@@ -277,6 +277,12 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.storage.name** : String (optional) - cookie name. Default: `_td`
 * **config.storage.expires** : Number (optional) - cookie expiration in seconds. When 0 it will expire with the session. Default: `63072000` (2 years)
 * **config.storage.domain** : String (optional) - cookie domain. Default: result of `document.location.hostname`
+
+**Server Side Cookie:**
+* **useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie - Default False
+* **config.cookieDomain** : String | (String) => String (optional) - Domain against which the Server Side Cokkie is set Default: `window.location.hostname`
+* **config.cookieDomainHost** : String (optional) - hostname to request server side cookie from Default `ssc.${cookieDomain}`
+
 
 **Personalization parameters**
 
@@ -504,6 +510,31 @@ td.setSignedMode()
 td.inSignedMode() // true
 td.trackEvent('willbetracked') // will send td_ip and td_client_id; td_global_id will also be sent if set.
 ```
+
+### Treasure#fetchServerCookie(success, failure, forceFetch)
+
+**Parameters:**
+
+* **success** : Function (optional) - Callback for when sending the event is successful
+* **error** : Function (optional) - Callback for when sending the event is unsuccessful
+* **forceFetch** : Boolean (optional) - Forces a refetch of server side id and ignores cached version (default false)
+
+**Example:**
+
+```javascript
+var td = new Treasure({...})
+
+var successCallback = function (serverSideId) {
+  // celebrate();
+};
+
+var errorCallback = function (error) {
+  // cry();
+}
+
+td.fetchServerCookie(successCallback, errorCallback)
+```
+
 
 ### Treasure#resetUUID
 

--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ If the database does not exist and you have permissions, it will be created for 
 
 **Server Side Cookie:**
 * **config.useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie - Default False
-* **config.cookieDomain** : String | (String) => String (optional) - Domain against which the Server Side Cokkie is set Default: `window.location.hostname`
-* **config.cookieDomainHost** : String (optional) - hostname to request server side cookie from Default `ssc.${cookieDomain}`
+* **config.sscDomain** : String | (String) => String (optional) - Domain against which the Server Side Cokkie is set Default: `window.location.hostname`
+* **config.sscServer** : String (optional) - hostname to request server side cookie from Default `ssc.${sscDomain}`
 
 
 **Personalization parameters**

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install td-js-sdk on your page by copying the appropriate JavaScript snippet bel
 
 ```html
 <script type="text/javascript">
-!function(t,e){if(void 0===e[t]){e[t]=function(){e[t].clients.push(this),this._init=[Array.prototype.slice.call(arguments)]},e[t].clients=[];for(var r=function(t){return function(){return this["_"+t]=this["_"+t]||[],this["_"+t].push(Array.prototype.slice.call(arguments)),this}},s=["blockEvents","unblockEvents","setSignedMode","setAnonymousMode","resetUUID","addRecord","fetchGlobalID","set","fetchServerCookie","trackEvent","trackPageview","trackClicks","ready"],n=0;n<s.length;n++){var c=s[n];e[t].prototype[c]=r(c)}var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.treasuredata.com/sdk/2.1/td.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(o,a)}}("Treasure",this);
+!function(t,e){if(void 0===e[t]){e[t]=function(){e[t].clients.push(this),this._init=[Array.prototype.slice.call(arguments)]},e[t].clients=[];for(var r=function(t){return function(){return this["_"+t]=this["_"+t]||[],this["_"+t].push(Array.prototype.slice.call(arguments)),this}},s=["blockEvents","unblockEvents","setSignedMode","setAnonymousMode","resetUUID","addRecord","fetchGlobalID","set","setSignedMode", "fetchServerCookie","trackEvent","trackPageview","trackClicks","ready"],n=0;n<s.length;n++){var c=s[n];e[t].prototype[c]=r(c)}var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.treasuredata.com/sdk/2.2.0/td.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(o,a)}}("Treasure",this);
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.globalIdCookie** : String (optional) - cookie td_globalid name. Default: `_td_global`
 * **config.startInSignedMode** : Boolean (optional) - Tell the SDK to default to Signed Mode if no choice is already made. Default: `false`
 * **config.jsonpTimeout** : Number (optional) - JSONP timeout (in milliseconds) Default: `10000`
+* **config.storeConsentByLocalStorage** : Boolean (optional) - Tell the SDK to use localStorage to store user consent. Default: `false`
 
 **Track/Storage parameters:**
 

--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ td.trackEvent('willbetracked') // will send td_ip and td_client_id; td_global_id
 ```
 
 ### Treasure#fetchServerCookie(success, failure, forceFetch)
+This functionality complies with ITP 1.2 tracking. Contact customer support for enabling this feature.
 
 **Parameters:**
 

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -28,7 +28,7 @@ function validateOptions (options) {
   )
 }
 
-var defaultSSCCookieDomain = (function () {
+var defaultSSCCookieDomain = function () {
   var domainChunks = document.location.hostname.split('.')
   for (var i = domainChunks.length - 2; i >= 1; i--) {
     var domain = domainChunks.slice(i).join('.')

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -37,7 +37,10 @@ exports.DEFAULT_CONFIG = {
   pathname: config.PATHNAME,
   requestType: 'jsonp',
   jsonpTimeout: 10000,
-  startInSignedMode: false
+  startInSignedMode: false,
+  cookieDomain: null,
+  cookieDomainHost: null,
+  useServerSideCookie: false
 }
 
 /**
@@ -71,7 +74,22 @@ exports.configure = function configure (options) {
   if (!this.client.endpoint) {
     this.client.endpoint = 'https://' + this.client.host + this.client.pathname
   }
-
+  if (this.useServerSideCookie) {
+    var defaultDomain = new window.URL(window.location.href).hostname
+      .split('.')
+      .slice(-2)
+      .join('.')
+    if (!this.options.cookieDomain) {
+      this.cookieDomain = defaultDomain
+    }
+    if (
+      typeof options.cookieDomain === 'function' &&
+      this.useServerSideCookie
+    ) {
+      this.cookieDomain = this.cookieDomain()
+    }
+    this.cookieDomainHost = ['ssc', this.cookieDomain].join('')
+  }
   return this
 }
 

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -6,6 +6,7 @@
 var _ = require('./utils/lodash')
 var invariant = require('./utils/misc').invariant
 var config = require('./config')
+var cookie = require('./vendor/js-cookies')
 
 // Helpers
 function validateOptions (options) {
@@ -27,7 +28,18 @@ function validateOptions (options) {
   )
 }
 
-var defaultCookieDomain = window.location.hostname.split('.').slice(-2).join('.')
+var defaultCookieDomain = (function () {
+  var domainChunks = document.location.hostname.split('.')
+  for (var i = domainChunks.length - 2; i >= 1; i--) {
+    var domain = domainChunks.slice(i).join('.')
+    var name = '_td_domain_' + domain // append domain name to avoid race condition
+    cookie.setItem(name, domain, 3600, '/', domain)
+    if (cookie.getItem(name) === domain) {
+      return domain
+    }
+  }
+  return document.location.hostname
+})()
 
 // Default config for library values
 exports.DEFAULT_CONFIG = {
@@ -41,7 +53,9 @@ exports.DEFAULT_CONFIG = {
   jsonpTimeout: 10000,
   startInSignedMode: false,
   cookieDomain: defaultCookieDomain,
-  cookieDomainHost: ['ssc', defaultCookieDomain].join('.'),
+  cookieDomainHost: function (cookieDomain) {
+    return ['ssc', cookieDomain].join('.')
+  },
   useServerSideCookie: false,
   storeConsentByLocalStorage: false
 }
@@ -76,11 +90,6 @@ exports.configure = function configure (options) {
 
   if (!this.client.endpoint) {
     this.client.endpoint = 'https://' + this.client.host + this.client.pathname
-  }
-  if (typeof this.client.cookieDomain === 'function' &&
-    this.client.useServerSideCookie
-  ) {
-    this.client.cookieDomain = this.client.cookieDomain(exports.DEFAULT_CONFIG.cookieDomain)
   }
   return this
 }

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -42,7 +42,8 @@ exports.DEFAULT_CONFIG = {
   startInSignedMode: false,
   cookieDomain: defaultCookieDomain,
   cookieDomainHost: ['ssc', defaultCookieDomain].join('.'),
-  useServerSideCookie: false
+  useServerSideCookie: false,
+  storeConsentByLocalStorage: false
 }
 
 /**

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -79,11 +79,10 @@ exports.configure = function configure (options) {
   if (!this.client.endpoint) {
     this.client.endpoint = 'https://' + this.client.host + this.client.pathname
   }
-  if (
-    options && typeof options.cookieDomain === 'function' &&
+  if (typeof this.client.cookieDomain === 'function' &&
     this.client.useServerSideCookie
   ) {
-    this.client.cookieDomain = options.cookieDomain(exports.DEFAULT_CONFIG.cookieDomain)
+    this.client.cookieDomain = this.client.cookieDomain(exports.DEFAULT_CONFIG.cookieDomain)
   }
   return this
 }

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -27,10 +27,7 @@ function validateOptions (options) {
   )
 }
 
-var defaultCookieDomain = new window.URL(window.location.href).hostname
-  .split('.')
-  .slice(-2)
-  .join('.')
+var defaultCookieDomain = window.location.hostname.split('.').slice(-2).join('.')
 
 // Default config for library values
 exports.DEFAULT_CONFIG = {

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -27,6 +27,11 @@ function validateOptions (options) {
   )
 }
 
+var defaultCookieDomain = new window.URL(window.location.href).hostname
+  .split('.')
+  .slice(-2)
+  .join('.')
+
 // Default config for library values
 exports.DEFAULT_CONFIG = {
   database: config.DATABASE,
@@ -38,8 +43,8 @@ exports.DEFAULT_CONFIG = {
   requestType: 'jsonp',
   jsonpTimeout: 10000,
   startInSignedMode: false,
-  cookieDomain: null,
-  cookieDomainHost: null,
+  cookieDomain: defaultCookieDomain,
+  cookieDomainHost: ['ssc', defaultCookieDomain].join('.'),
   useServerSideCookie: false
 }
 
@@ -74,21 +79,13 @@ exports.configure = function configure (options) {
   if (!this.client.endpoint) {
     this.client.endpoint = 'https://' + this.client.host + this.client.pathname
   }
-  if (this.useServerSideCookie) {
-    var defaultDomain = new window.URL(window.location.href).hostname
-      .split('.')
-      .slice(-2)
-      .join('.')
-    if (!this.options.cookieDomain) {
-      this.cookieDomain = defaultDomain
-    }
+  if (this.client.useServerSideCookie) {
     if (
       typeof options.cookieDomain === 'function' &&
-      this.useServerSideCookie
+      this.client.useServerSideCookie
     ) {
-      this.cookieDomain = this.cookieDomain()
+      this.client.cookieDomain = this.client.cookieDomain(exports.DEFAULT_CONFIG.cookieDomain)
     }
-    this.cookieDomainHost = ['ssc', this.cookieDomain].join('')
   }
   return this
 }

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -28,7 +28,7 @@ function validateOptions (options) {
   )
 }
 
-var defaultCookieDomain = (function () {
+var defaultSSCCookieDomain = (function () {
   var domainChunks = document.location.hostname.split('.')
   for (var i = domainChunks.length - 2; i >= 1; i--) {
     var domain = domainChunks.slice(i).join('.')
@@ -52,11 +52,11 @@ exports.DEFAULT_CONFIG = {
   requestType: 'jsonp',
   jsonpTimeout: 10000,
   startInSignedMode: false,
-  cookieDomain: defaultCookieDomain,
-  cookieDomainHost: function (cookieDomain) {
+  useServerSideCookie: false,
+  sscDomain: defaultSSCCookieDomain,
+  sscServer: function (cookieDomain) {
     return ['ssc', cookieDomain].join('.')
   },
-  useServerSideCookie: false,
   storeConsentByLocalStorage: false
 }
 

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -79,13 +79,11 @@ exports.configure = function configure (options) {
   if (!this.client.endpoint) {
     this.client.endpoint = 'https://' + this.client.host + this.client.pathname
   }
-  if (this.client.useServerSideCookie) {
-    if (
-      typeof options.cookieDomain === 'function' &&
-      this.client.useServerSideCookie
-    ) {
-      this.client.cookieDomain = this.client.cookieDomain(exports.DEFAULT_CONFIG.cookieDomain)
-    }
+  if (
+    options && typeof options.cookieDomain === 'function' &&
+    this.client.useServerSideCookie
+  ) {
+    this.client.cookieDomain = options.cookieDomain(exports.DEFAULT_CONFIG.cookieDomain)
   }
   return this
 }

--- a/lib/plugins/globalid.js
+++ b/lib/plugins/globalid.js
@@ -18,7 +18,9 @@ function configure () {}
 function fetchGlobalID (success, error, forceFetch) {
   success = success || noop
   error = error || noop
-
+  if (!this.inSignedMode()) {
+    return error('not in signed in mode')
+  }
   var cookieName = this.client.globalIdCookie
   var cachedGlobalId = cookie.getItem(this.client.globalIdCookie)
   if (cachedGlobalId && !forceFetch) {

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -1,0 +1,57 @@
+/**
+ * Treasure Server Side Cookie
+ */
+
+var jsonp = require('jsonp')
+var noop = require('../utils/misc').noop
+var invariant = require('../utils/misc').invariant
+var cookie = require('../vendor/js-cookies')
+
+var cookieName = 'td_ssc_cookie'
+
+function cacheSuccess (result, cookieName) {
+  cookie.setItem(cookieName, result['td_ssc_id'], 6000)
+  return result['td_ssc_id']
+}
+
+function configure (config) {
+  if (config.useServerSideCookie) {
+    cookie.getItem(cookieName)
+  }
+  return this
+}
+
+function fetchServerCookie (success, error, forceFetch) {
+  success = success || noop
+  error = error || noop
+
+  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id'
+
+  var cachedSSCId = cookie.getItem(cookieName)
+  if (cachedSSCId && !forceFetch) {
+    return setTimeout(function () {
+      success(cachedSSCId)
+    }, 0)
+  }
+
+  invariant(
+    this.client.requestType === 'jsonp',
+    'Request type ' + this.client.requestType + ' not supported'
+  )
+
+  jsonp(
+    url,
+    {
+      prefix: 'TreasureJSONPCallback',
+      timeout: this.client.jsonpTimeout
+    },
+    function (err, res) {
+      return err ? error(err) : success(cacheSuccess(res, cookieName))
+    }
+  )
+}
+
+module.exports = {
+  configure: configure,
+  fetchServerCookie: fetchServerCookie
+}

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -17,7 +17,7 @@ function fetchServerCookie (success, error, forceFetch) {
   success = success || noop
   error = error || noop
 
-  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id?cookieDomain=' + window.encodeURI(this.client.cookieDomain) + '&r=' + new Date().getTime()
+  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id?cookie_domain=' + window.encodeURI(this.client.cookieDomain) + '&r=' + new Date().getTime()
   var cachedSSCId = cookie.getItem(cookieName)
   if (cachedSSCId && !forceFetch) {
     return setTimeout(function () {

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -23,15 +23,15 @@ function fetchServerCookie (success, error, forceFetch) {
     return error('server side cookie not enabled')
   }
   if (!this._serverCookieDomainHost) {
-    if (typeof this.client.cookieDomain === 'function') {
-      this._serverCookieDomain = this.client.cookieDomain()
+    if (typeof this.client.sscDomain === 'function') {
+      this._serverCookieDomain = this.client.sscDomain()
     } else {
-      this._serverCookieDomain = this.client.cookieDomain
+      this._serverCookieDomain = this.client.sscDomain
     }
-    if (typeof this.client.cookieDomainHost === 'function') {
-      this._serverCookieDomainHost = this.client.cookieDomainHost(this._serverCookieDomain)
+    if (typeof this.client.sscServer === 'function') {
+      this._serverCookieDomainHost = this.client.sscServer(this._serverCookieDomain)
     } else {
-      this._serverCookieDomainHost = this.client.cookieDomainHost
+      this._serverCookieDomainHost = this.client.sscServer
     }
   }
   var url = 'https://' + this._serverCookieDomainHost + '/get_cookie_id?cookie_domain=' + window.encodeURI(this._serverCookieDomain) + '&r=' + new Date().getTime()

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -53,5 +53,6 @@ function fetchServerCookie (success, error, forceFetch) {
 
 module.exports = {
   configure: configure,
+  cacheSuccess: cacheSuccess,
   fetchServerCookie: fetchServerCookie
 }

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -7,17 +7,9 @@ var noop = require('../utils/misc').noop
 var invariant = require('../utils/misc').invariant
 var cookie = require('../vendor/js-cookies')
 
-var cookieName = 'td_ssc_cookie'
+var cookieName = 'td_ssc_id'
 
-function cacheSuccess (result, cookieName) {
-  cookie.setItem(cookieName, result['td_ssc_id'], 6000)
-  return result['td_ssc_id']
-}
-
-function configure (config) {
-  if (config.useServerSideCookie) {
-    cookie.getItem(cookieName)
-  }
+function configure () {
   return this
 }
 
@@ -25,8 +17,7 @@ function fetchServerCookie (success, error, forceFetch) {
   success = success || noop
   error = error || noop
 
-  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id'
-
+  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id?cookieDomain=' + window.encodeURI(this.client.cookieDomain) + '&r=' + Math.floor(Math.random() * 500000)
   var cachedSSCId = cookie.getItem(cookieName)
   if (cachedSSCId && !forceFetch) {
     return setTimeout(function () {
@@ -46,13 +37,12 @@ function fetchServerCookie (success, error, forceFetch) {
       timeout: this.client.jsonpTimeout
     },
     function (err, res) {
-      return err ? error(err) : success(cacheSuccess(res, cookieName))
+      return err ? error(err) : success(res.td_ssc_id)
     }
   )
 }
 
 module.exports = {
   configure: configure,
-  cacheSuccess: cacheSuccess,
   fetchServerCookie: fetchServerCookie
 }

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -7,7 +7,7 @@ var noop = require('../utils/misc').noop
 var invariant = require('../utils/misc').invariant
 var cookie = require('../vendor/js-cookies')
 
-var cookieName = 'td_ssc_id'
+var cookieName = '_td_ssc_id'
 
 function configure () {
   return this
@@ -17,7 +17,7 @@ function fetchServerCookie (success, error, forceFetch) {
   success = success || noop
   error = error || noop
 
-  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id?cookieDomain=' + window.encodeURI(this.client.cookieDomain) + '&r=' + Math.floor(Math.random() * 500000)
+  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id?cookieDomain=' + window.encodeURI(this.client.cookieDomain) + '&r=' + new Date().getTime()
   var cachedSSCId = cookie.getItem(cookieName)
   if (cachedSSCId && !forceFetch) {
     return setTimeout(function () {
@@ -37,7 +37,7 @@ function fetchServerCookie (success, error, forceFetch) {
       timeout: this.client.jsonpTimeout
     },
     function (err, res) {
-      return err ? error(err) : success(res.td_ssc_id || res._td_ssc_id)
+      return err ? error(err) : success(res.td_ssc_id)
     }
   )
 }

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -16,7 +16,9 @@ function configure () {
 function fetchServerCookie (success, error, forceFetch) {
   success = success || noop
   error = error || noop
-
+  if (!this.inSignedMode()) {
+    return error('not in signed in mode')
+  }
   var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id?cookie_domain=' + window.encodeURI(this.client.cookieDomain) + '&r=' + new Date().getTime()
   var cachedSSCId = cookie.getItem(cookieName)
   if (cachedSSCId && !forceFetch) {

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -37,7 +37,7 @@ function fetchServerCookie (success, error, forceFetch) {
       timeout: this.client.jsonpTimeout
     },
     function (err, res) {
-      return err ? error(err) : success(res.td_ssc_id)
+      return err ? error(err) : success(res.td_ssc_id || res._td_ssc_id)
     }
   )
 }

--- a/lib/plugins/servercookie.js
+++ b/lib/plugins/servercookie.js
@@ -19,7 +19,22 @@ function fetchServerCookie (success, error, forceFetch) {
   if (!this.inSignedMode()) {
     return error('not in signed in mode')
   }
-  var url = 'https://' + this.client.cookieDomainHost + '/get_cookie_id?cookie_domain=' + window.encodeURI(this.client.cookieDomain) + '&r=' + new Date().getTime()
+  if (!this.client.useServerSideCookie) {
+    return error('server side cookie not enabled')
+  }
+  if (!this._serverCookieDomainHost) {
+    if (typeof this.client.cookieDomain === 'function') {
+      this._serverCookieDomain = this.client.cookieDomain()
+    } else {
+      this._serverCookieDomain = this.client.cookieDomain
+    }
+    if (typeof this.client.cookieDomainHost === 'function') {
+      this._serverCookieDomainHost = this.client.cookieDomainHost(this._serverCookieDomain)
+    } else {
+      this._serverCookieDomainHost = this.client.cookieDomainHost
+    }
+  }
+  var url = 'https://' + this._serverCookieDomainHost + '/get_cookie_id?cookie_domain=' + window.encodeURI(this._serverCookieDomain) + '&r=' + new Date().getTime()
   var cachedSSCId = cookie.getItem(cookieName)
   if (cachedSSCId && !forceFetch) {
     return setTimeout(function () {

--- a/lib/record.js
+++ b/lib/record.js
@@ -7,6 +7,7 @@ var invariant = require('./utils/misc').invariant
 var noop = require('./utils/misc').noop
 var jsonp = require('jsonp')
 var _ = require('./utils/lodash')
+var global = require('global')
 var cookie = require('./vendor/js-cookies')
 var setCookie = require('./utils/setCookie')
 
@@ -68,7 +69,11 @@ exports.areEventsBlocked = function areEventsBlocked () {
  * Sets the user to Signed Mode
  */
 exports.setSignedMode = function setSignedMode (signedMode) {
-  setCookie(this.client.storage, SIGNEDMODECOOKIE, 'true')
+  if (this.client.storeConsentByLocalStorage) {
+    global.localStorage.setItem(SIGNEDMODECOOKIE, 'true')
+  } else {
+    setCookie(this.client.storage, SIGNEDMODECOOKIE, 'true')
+  }
   return this
 }
 
@@ -78,7 +83,11 @@ exports.setSignedMode = function setSignedMode (signedMode) {
  * Sets the user to anonymous mode
  */
 exports.setAnonymousMode = function setAnonymousMode (signedMode) {
-  setCookie(this.client.storage, SIGNEDMODECOOKIE, 'false')
+  if (this.client.storeConsentByLocalStorage) {
+    global.localStorage.setItem(SIGNEDMODECOOKIE, 'false')
+  } else {
+    setCookie(this.client.storage, SIGNEDMODECOOKIE, 'false')
+  }
   return this
 }
 
@@ -88,6 +97,11 @@ exports.setAnonymousMode = function setAnonymousMode (signedMode) {
  * Tells whether or not the user is in Signed Mode
  */
 exports.inSignedMode = function inSignedMode () {
+  if (this.client.storeConsentByLocalStorage) {
+    return global.localStorage.getItem([SIGNEDMODECOOKIE]) !== 'false' &&
+    (global.localStorage.getItem([SIGNEDMODECOOKIE]) === 'true' ||
+    this.client.startInSignedMode)
+  }
   return cookie.getItem(SIGNEDMODECOOKIE) !== 'false' &&
     (cookie.getItem(SIGNEDMODECOOKIE) === 'true' ||
     this.client.startInSignedMode)

--- a/lib/treasure.js
+++ b/lib/treasure.js
@@ -104,7 +104,8 @@ Treasure.Plugins = {
   Clicks: require('./plugins/clicks'),
   GlobalID: require('./plugins/globalid'),
   Personalization: require('./plugins/personalization'),
-  Track: require('./plugins/track')
+  Track: require('./plugins/track'),
+  ServerSideCookie: require('./plugins/servercookie')
 }
 
 // Load all plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "td-js-sdk",
-  "version": "ITP-1.2-beta1",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "bugs": "https://github.com/treasure-data/td-js-sdk/issues",
   "description": "Browser JS library for sending events to your Treasure Data account",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "td-js-sdk",
-  "version": "2.1.0",
+  "version": "ITP-1.2-beta1",
   "license": "Apache-2.0",
   "bugs": "https://github.com/treasure-data/td-js-sdk/issues",
   "description": "Browser JS library for sending events to your Treasure Data account",

--- a/src/loader.js
+++ b/src/loader.js
@@ -14,7 +14,7 @@
       }
     }
 
-    var methods = ['blockEvents', 'unblockEvents', 'setSignedMode', 'setAnonymousMode', 'resetUUID', 'addRecord', 'fetchGlobalID', 'set', 'trackEvent', 'trackPageview', 'trackClicks', 'ready']
+    var methods = ['blockEvents', 'setSignedMode', 'fetchServerCookie', 'unblockEvents', 'setSignedMode', 'setAnonymousMode', 'resetUUID', 'addRecord', 'fetchGlobalID', 'set', 'trackEvent', 'trackPageview', 'trackClicks', 'ready']
     for (var i = 0; i < methods.length; i++) {
       var method = methods[i]
       c[n].prototype[method] = action(method)

--- a/test/e2e/globalid.spec.js
+++ b/test/e2e/globalid.spec.js
@@ -2,38 +2,48 @@ var test = require('tape')
 
 module.exports = function (browser, initOpts, finish) {
   test('globalid test', function (t) {
-    t.plan(1)
+    var count = 2
+    t.plan(2)
 
-    function initTest () {
-      browser.get('http://localhost:9999/fixtures/globalid', getStatus)
+    function finished () {
+      count--
+      if (count === 0) {
+        t.end()
+        browser.quit()
+        finish()
+      }
     }
 
-    function getStatus () {
-      browser.elementById('status', function (err, el) {
-        return err ? t.fail('Error', err) : el.text(getText)
+    function initTest () {
+      browser.get('http://localhost:9999/fixtures/globalid', function () {
+        getStatus(0)
+        getStatus(1)
       })
     }
 
-    function getText (err, text) {
-      if (err) {
-        t.fail('Error', err)
-        t.end()
-        browser.quit()
-        return finish()
+    function getStatus (num) {
+      browser.elementById('status' + num, function (err, el) {
+        return err ? t.fail('Error', err) : el.text(getText(num))
+      })
+    }
+
+    function getText (num) {
+      return function (err, text) {
+        if (err) {
+          t.fail('Error', err)
+          return finished()
+        }
+        switch (text) {
+          case 'success':
+            t.pass('status is success')
+            return finished()
+          case 'failure':
+            t.fail('status is failure')
+            return finished()
+          default:
+            return getStatus(num)
+        }
       }
-      switch (text) {
-        case 'success':
-          t.pass('status is success')
-          break
-        case 'failure':
-          t.fail('status is failure')
-          break
-        default:
-          return getStatus()
-      }
-      t.end()
-      browser.quit()
-      finish()
     }
 
     browser.init(initOpts, initTest)

--- a/test/e2e/servercookie.spec.js
+++ b/test/e2e/servercookie.spec.js
@@ -2,38 +2,49 @@ var test = require('tape')
 
 module.exports = function (browser, initOpts, finish) {
   test('server cookie test', function (t) {
+    var count = 2
     t.plan(2)
 
-    function initTest () {
-      browser.get('http://localhost:9999/fixtures/servercookie', getStatus)
+    function finished () {
+      count--
+      if (count === 0) {
+        t.end()
+        browser.quit()
+        finish()
+      }
     }
 
-    function getStatus () {
-      browser.elementById('status', function (err, el) {
-        return err ? t.fail('Error', err) : el.text(getText)
+    function initTest () {
+      browser.get('http://localhost:9999/fixtures/servercookie', function () {
+        getStatus(0)
+        getStatus(1)
+        getStatus(2)
       })
     }
 
-    function getText (err, text) {
-      if (err) {
-        t.fail('Error', err)
-        t.end()
-        browser.quit()
-        return finish()
+    function getStatus (num) {
+      browser.elementById('status' + num, function (err, el) {
+        return err ? t.fail('Error', err) : el.text(getText(num))
+      })
+    }
+
+    function getText (num) {
+      return function (err, text) {
+        if (err) {
+          t.fail('Error', err)
+          return finished()
+        }
+        switch (text) {
+          case 'success':
+            t.pass('status is success')
+            return finished()
+          case 'failure':
+            t.fail('status is failure')
+            return finished()
+          default:
+            return getStatus(num)
+        }
       }
-      switch (text) {
-        case 'success':
-          t.pass('status is success')
-          break
-        case 'failure':
-          t.fail('status is failure')
-          break
-        default:
-          return getStatus()
-      }
-      t.end()
-      browser.quit()
-      finish()
     }
 
     browser.init(initOpts, initTest)

--- a/test/e2e/servercookie.spec.js
+++ b/test/e2e/servercookie.spec.js
@@ -1,0 +1,41 @@
+var test = require('tape')
+
+module.exports = function (browser, initOpts, finish) {
+  test('server cookie test', function (t) {
+    t.plan(2)
+
+    function initTest () {
+      browser.get('http://localhost:9999/fixtures/servercookie', getStatus)
+    }
+
+    function getStatus () {
+      browser.elementById('status', function (err, el) {
+        return err ? t.fail('Error', err) : el.text(getText)
+      })
+    }
+
+    function getText (err, text) {
+      if (err) {
+        t.fail('Error', err)
+        t.end()
+        browser.quit()
+        return finish()
+      }
+      switch (text) {
+        case 'success':
+          t.pass('status is success')
+          break
+        case 'failure':
+          t.fail('status is failure')
+          break
+        default:
+          return getStatus()
+      }
+      t.end()
+      browser.quit()
+      finish()
+    }
+
+    browser.init(initOpts, initTest)
+  })
+}

--- a/test/fixtures/globalid/index.html
+++ b/test/fixtures/globalid/index.html
@@ -15,8 +15,18 @@
       document.body.style.background = color
     }
 
-    function setStatus (text) {
-      document.getElementById('status').innerHTML = text
+    function setStatus (num, text) {
+      document.getElementById('status' + num).innerHTML = text
+      status[num] = text
+      if (status.length === 2) {
+        var isFailure = false
+        for (var i = 0; i < status.length; i++) {
+          if (status[i] === 'failure') {
+            isFailure = true
+          }
+        }
+        document.body.style.background = isFailure ? 'red' : 'green'
+      }
     }
 
     var td = new Treasure({
@@ -24,18 +34,31 @@
       writeKey: '91/96da3cfb876cc50724d0dddef670d95eea2a0018',
       host: 'in.treasuredata.com'
     })
-
+    td.setSignedMode()
     td.fetchGlobalID(function (value) {
       setBackground('green')
-      setStatus('success')
+      setStatus(0, 'success')
+      td.setSignedMode()
+      td.setAnonymousMode()
+      console.log('a')
+      td.fetchGlobalID(function() {
+        console.log('b')
+        setStatus(1, 'failure')
+      }, function(error) {
+        console.log('c')
+        setStatus(1, 'success')
+      })
+
     }, function () {
       setBackground('red')
-      setStatus('failure')
+      setStatus(0, 'failure')
+      setStatus(1, 'failure')
     }, true)
   })()
 </script>
 
-<h1 id='status' style="text-align: center;">running</h1>
+<h1 id='status0' style="text-align: center;">running</h1>
+<h1 id='status1' style="text-align: center;">running</h1>
 
 </body>
 </html>

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -18,6 +18,7 @@
   <li><a id='slow' href="/fixtures/slow">slow</a></li>
   <li><a id='globalid' href="/fixtures/globalid">globalid</a></li>
   <li><a id='usersegment' href="/fixtures/usersegment">usersegment</a></li>
+  <li><a id='usersegment' href="/fixtures/servercookie">servercookie</a></li>
 </ol>
 
 </body>

--- a/test/fixtures/servercookie/index.html
+++ b/test/fixtures/servercookie/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>servercookie</title>
+  <meta name="description" content="test that globalid tracking works"></meta>
+  <script src="/dist/td.js"></script>
+</head>
+<body>
+
+<script type="text/javascript">
+  (function () {
+    function setBackground (color) {
+      document.body.style.background = color
+    }
+
+    function setStatus (num, text) {
+      document.getElementById('status' + num).innerHTML = text
+      status[num] = text
+      if (status.length === 3) {
+        var isFailure = false
+        for (var i = 0; i < status.length; i++) {
+          if (status[i] === 'failure') {
+            isFailure = true
+          }
+        }
+        document.body.style.background = isFailure ? 'red' : 'green'
+      }
+    }
+
+    var status = []
+
+    var td = new Treasure({
+      database: 'test_db_request',
+      writeKey: '91/96da3cfb876cc50724d0dddef670d95eea2a0018',
+      host: 'in-staging.treasuredata.com',
+      cookieDomainHost: 'ssc.treasuredata.com',
+      useServerSideCookie: true,
+    })
+
+    td.fetchServerCookie(function (value1) {
+      setStatus(0, 'success')
+      td.fetchServerCookie(function (value2) {
+        if(value1 === value2) {
+          setStatus(1, 'success')
+        }
+      }, function () {
+        setStatus(1, 'failure')
+      })
+    }, function () {
+      setBackground('red')
+      setStatus(0, 'failure')
+      setStatus(1, 'failure')
+    }, true)
+  })()
+</script>
+
+<h1 id='status0' style="text-align: center;">running</h1>
+<h1 id='status1' style="text-align: center;">running</h1>
+
+</body>
+</html>

--- a/test/fixtures/servercookie/index.html
+++ b/test/fixtures/servercookie/index.html
@@ -35,8 +35,6 @@
       database: 'test_db_request',
       writeKey: '91/96da3cfb876cc50724d0dddef670d95eea2a0018',
       host: 'in-staging.treasuredata.com',
-      cookieDomain: 'localhost',
-      cookieDomainHost: 'ssc.treasuredata.com',
       useServerSideCookie: true,
     })
     td.setSignedMode()

--- a/test/fixtures/servercookie/index.html
+++ b/test/fixtures/servercookie/index.html
@@ -35,19 +35,18 @@
       database: 'test_db_request',
       writeKey: '91/96da3cfb876cc50724d0dddef670d95eea2a0018',
       host: 'in-staging.treasuredata.com',
-      cookieDomain: 'console-local.treasure-data.com',
+      cookieDomain: 'localhost',
       cookieDomainHost: 'ssc.treasuredata.com',
       useServerSideCookie: true,
     })
-
+    td.setSignedMode()
     td.fetchServerCookie(function (value1) {
       setStatus(0, 'success')
-      td.fetchServerCookie(function (value2) {
-        if(value1 === value2) {
-          setStatus(1, 'success')
-        }
-      }, function () {
+      td.setAnonymousMode()
+      td.fetchServerCookie(function(){
         setStatus(1, 'failure')
+      }, function(error) {
+        setStatus(1, 'success')
       })
     }, function () {
       setBackground('red')

--- a/test/fixtures/servercookie/index.html
+++ b/test/fixtures/servercookie/index.html
@@ -18,7 +18,7 @@
     function setStatus (num, text) {
       document.getElementById('status' + num).innerHTML = text
       status[num] = text
-      if (status.length === 3) {
+      if (status.length === 2) {
         var isFailure = false
         for (var i = 0; i < status.length; i++) {
           if (status[i] === 'failure') {

--- a/test/fixtures/servercookie/index.html
+++ b/test/fixtures/servercookie/index.html
@@ -35,6 +35,7 @@
       database: 'test_db_request',
       writeKey: '91/96da3cfb876cc50724d0dddef670d95eea2a0018',
       host: 'in-staging.treasuredata.com',
+      cookieDomain: 'console-local.treasure-data.com',
       cookieDomainHost: 'ssc.treasuredata.com',
       useServerSideCookie: true,
     })

--- a/test/treasure.recording.spec.js
+++ b/test/treasure.recording.spec.js
@@ -399,7 +399,7 @@ describe('Treasure Record', function () {
         expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_ip')
         expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_client_id')
       })
-      describe('cookie anonymous mode', () => {
+      describe('cookie anonymous mode', function () {
         it('should block the generated PII records from being sent in tracking values if desired', function () {
           treasure.setAnonymousMode()
           treasure.trackEvent('foo', {})
@@ -422,7 +422,7 @@ describe('Treasure Record', function () {
           expect(treasure.inSignedMode()).to.be(false)
         })
       })
-      describe('localStorage anonymous mode', () => {
+      describe('localStorage anonymous mode', function () {
         beforeEach(function () {
           treasure = new Treasure({
             database: 'database',

--- a/test/treasure.recording.spec.js
+++ b/test/treasure.recording.spec.js
@@ -399,51 +399,108 @@ describe('Treasure Record', function () {
         expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_ip')
         expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_client_id')
       })
-      it('should block the generated PII records from being sent in tracking values if desired', function () {
-        treasure.setAnonymousMode()
-        treasure.trackEvent('foo', {})
-        expect(treasure._sendRecord.callCount).to.be(1)
-        expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_ip')
-        expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_client_id')
+      describe('cookie anonymous mode', () => {
+        it('should block the generated PII records from being sent in tracking values if desired', function () {
+          treasure.setAnonymousMode()
+          treasure.trackEvent('foo', {})
+          expect(treasure._sendRecord.callCount).to.be(1)
+          expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_ip')
+          expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_client_id')
+        })
+        it('should block the generated PII records from being sent in set values as well', function () {
+          treasure.set('$global', 'td_global_id', 'td_global_id')
+          treasure.setAnonymousMode()
+          treasure.trackEvent('foo', {})
+          expect(treasure._sendRecord.callCount).to.be(1)
+          expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_global_id')
+        })
+        it('inSignedMode() will return true if in Signed Mode', function () {
+          expect(treasure.inSignedMode()).to.be(false)
+          treasure.setSignedMode()
+          expect(treasure.inSignedMode()).to.be(true)
+          treasure.setAnonymousMode()
+          expect(treasure.inSignedMode()).to.be(false)
+        })
       })
-      it('should block the generated PII records from being sent in set values as well', function () {
-        treasure.set('$global', 'td_global_id', 'td_global_id')
-        treasure.setAnonymousMode()
-        treasure.trackEvent('foo', {})
-        expect(treasure._sendRecord.callCount).to.be(1)
-        expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_global_id')
-      })
-      it('inSignedMode() will return true if in Signed Mode', function () {
-        expect(treasure.inSignedMode()).to.be(false)
-        treasure.setSignedMode()
-        expect(treasure.inSignedMode()).to.be(true)
-        treasure.setAnonymousMode()
-        expect(treasure.inSignedMode()).to.be(false)
+      describe('localStorage anonymous mode', () => {
+        beforeEach(function () {
+          treasure = new Treasure({
+            database: 'database',
+            writeKey: 'writeKey',
+            storeConsentByLocalStorage: true
+          })
+          simple.mock(treasure, '_sendRecord')
+        })
+
+        afterEach(function () {
+          simple.restore()
+        })
+
+        it('should block the generated PII records from being sent in tracking values if desired', function () {
+          treasure.setAnonymousMode()
+          treasure.trackEvent('foo', {})
+          expect(treasure._sendRecord.callCount).to.be(1)
+          expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_ip')
+          expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_client_id')
+        })
+        it('should block the generated PII records from being sent in set values as well', function () {
+          treasure.set('$global', 'td_global_id', 'td_global_id')
+          treasure.setAnonymousMode()
+          treasure.trackEvent('foo', {})
+          expect(treasure._sendRecord.callCount).to.be(1)
+          expect(treasure._sendRecord.calls[0].args[0].record).not.to.have.property('td_global_id')
+        })
+        it('inSignedMode() will return true if in Signed Mode', function () {
+          expect(treasure.inSignedMode()).to.be(false)
+          treasure.setSignedMode()
+          expect(treasure.inSignedMode()).to.be(true)
+          treasure.setAnonymousMode()
+          expect(treasure.inSignedMode()).to.be(false)
+        })
       })
       describe('startInSignedMode', function () {
-        function makeNewTD (startInSignedMode) {
+        function makeNewTD (startInSignedMode, storeConsentByLocalStorage) {
           resetConfiguration({
-            startInSignedMode: startInSignedMode
+            startInSignedMode: startInSignedMode,
+            storeConsentByLocalStorage: storeConsentByLocalStorage
           })
           treasure = new Treasure(configuration)
         }
 
         it('will favor cookies if set', function () {
           cookie.setItem(SIGNEDMODECOOKIE, 'true')
-          makeNewTD(false)
+          makeNewTD(false, false)
           expect(treasure.inSignedMode()).to.be(true)
 
           cookie.setItem(SIGNEDMODECOOKIE, 'false')
-          makeNewTD(true)
+          makeNewTD(true, false)
           expect(treasure.inSignedMode()).to.be(false)
         })
         it('will start in Signed Mode if cookie is not set', function () {
           cookie.removeItem(SIGNEDMODECOOKIE)
-          makeNewTD(false)
+          makeNewTD(false, false)
           expect(treasure.inSignedMode()).to.be(false)
 
           expect(cookie.getItem(SIGNEDMODECOOKIE)).to.not.be.ok()
-          makeNewTD(true)
+          makeNewTD(true, false)
+          expect(treasure.inSignedMode()).to.be(true)
+        })
+        it('will favor localStorage if set', function () {
+          window.localStorage.setItem(SIGNEDMODECOOKIE, 'true')
+          makeNewTD(false, true)
+          expect(treasure.inSignedMode()).to.be(true)
+
+          window.localStorage.setItem(SIGNEDMODECOOKIE, 'false')
+          makeNewTD(true, true)
+          expect(treasure.inSignedMode()).to.be(false)
+        })
+        it('will start in Signed Mode if localStorage is not set', function () {
+          window.localStorage.removeItem(SIGNEDMODECOOKIE)
+          makeNewTD(false, true)
+          expect(treasure.inSignedMode()).to.be(false)
+
+          expect(window.localStorage.getItem(SIGNEDMODECOOKIE)).to.not.be.ok()
+          makeNewTD(true, true)
           expect(treasure.inSignedMode()).to.be(true)
         })
       })

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -1,6 +1,5 @@
 var expect = require('expect.js')
 var Treasure = require('../lib/treasure')
-var ServerCookie = require('../lib/plugins/servercookie')
 var cookie = require('../lib/vendor/js-cookies')
 
 describe('Treasure Server Cookie', function () {
@@ -14,14 +13,16 @@ describe('Treasure Server Cookie', function () {
     expect(typeof td.fetchServerCookie === 'function').ok()
   })
 
-  describe('cacheSuccess', function () {
+  describe('cookie ', function () {
     beforeEach(function () {
-      cookie.removeItem('foo')
+      cookie.setItem('td_ssc_id', 'foo')
     })
-    it('should set cookie and return value', function () {
-      expect(cookie.getItem('foo')).to.be(null)
-      expect(ServerCookie.cacheSuccess({ td_ssc_id: '42' }, 'foo')).to.be('42')
-      expect(cookie.getItem('foo')).to.be('42')
+    it('should return td_ssc_id from cookie if available', function (done) {
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey' })
+      td.fetchServerCookie(function (val) {
+        expect(val).to.be('foo')
+        done()
+      })
     })
   })
 })

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -4,9 +4,18 @@ var cookie = require('../lib/vendor/js-cookies')
 
 describe('Treasure Server Cookie', function () {
   describe('configure', () => {
-    it('should support cookieDomain as string', () => {})
-    it('should support cookieDomain as function', () => {})
-    it('should create cookieDomainHost based on cookieDomain, as default', () => {})
+    it('should support cookieDomain as string', () => {
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: 'foo' })
+      expect(td.client.cookieDomain).to.be('foo')
+    })
+    it('should support cookieDomain as function', () => {
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: () => 'foo' })
+      expect(td.client.cookieDomain).to.be('foo')
+    })
+    it('should create cookieDomainHost based on cookieDomain, as default', () => {
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey' })
+      expect(td.client.cookieDomainHost).to.be('ssc.localhost')
+    })
   })
   it('adds fetchServerCookie method', function () {
     var td = new Treasure({ database: 'foo', writeKey: 'writeKey' })

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -5,7 +5,7 @@ var cookie = require('../lib/vendor/js-cookies')
 describe('Treasure Server Cookie', function () {
   describe('configure', function () {
     it('should support cookieDomain as string', function () {
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', sscDomain: 'foo', useServerSideCookie: true, })
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', sscDomain: 'foo', useServerSideCookie: true })
       expect(td.client.cookieDomain).to.be('foo')
     })
     it('should support cookieDomain as function', function () {

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -9,12 +9,9 @@ describe('Treasure Server Cookie', function () {
       expect(td.client.cookieDomain).to.be('foo')
     })
     it('should support cookieDomain as function', function () {
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: function () { return 'foo' }})
-      expect(td.client.cookieDomain).to.be('foo')
-    })
-    it('should create cookieDomainHost based on cookieDomain, as default', function () {
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey' })
-      expect(td.client.cookieDomainHost).to.be('ssc.localhost')
+      var foo = function () { return 'foo' }
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: foo })
+      expect(td.client.cookieDomain).to.be(foo)
     })
   })
   it('adds fetchServerCookie method', function () {

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -3,16 +3,16 @@ var Treasure = require('../lib/treasure')
 var cookie = require('../lib/vendor/js-cookies')
 
 describe('Treasure Server Cookie', function () {
-  describe('configure', () => {
+  describe('configure', function () {
     it('should support cookieDomain as string', function () {
       var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: 'foo' })
       expect(td.client.cookieDomain).to.be('foo')
     })
     it('should support cookieDomain as function', function () {
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: () => 'foo' })
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: function () { return 'foo' }})
       expect(td.client.cookieDomain).to.be('foo')
     })
-    it('should create cookieDomainHost based on cookieDomain, as default', () => {
+    it('should create cookieDomainHost based on cookieDomain, as default', function () {
       var td = new Treasure({ database: 'foo', writeKey: 'writeKey' })
       expect(td.client.cookieDomainHost).to.be('ssc.localhost')
     })

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -1,0 +1,27 @@
+var expect = require('expect.js')
+var Treasure = require('../lib/treasure')
+var ServerCookie = require('../lib/plugins/servercookie')
+var cookie = require('../lib/vendor/js-cookies')
+
+describe('Treasure Server Cookie', function () {
+  describe('configure', () => {
+    it('should support cookieDomain as string', () => {})
+    it('should support cookieDomain as function', () => {})
+    it('should create cookieDomainHost based on cookieDomain, as default', () => {})
+  })
+  it('adds fetchServerCookie method', function () {
+    var td = new Treasure({ database: 'foo', writeKey: 'writeKey' })
+    expect(typeof td.fetchServerCookie === 'function').ok()
+  })
+
+  describe('cacheSuccess', function () {
+    beforeEach(function () {
+      cookie.removeItem('foo')
+    })
+    it('should set cookie and return value', function () {
+      expect(cookie.getItem('foo')).to.be(null)
+      expect(ServerCookie.cacheSuccess({ td_ssc_id: '42' }, 'foo')).to.be('42')
+      expect(cookie.getItem('foo')).to.be('42')
+    })
+  })
+})

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -5,14 +5,14 @@ var cookie = require('../lib/vendor/js-cookies')
 describe('Treasure Server Cookie', function () {
   describe('configure', function () {
     it('should support cookieDomain as string', function () {
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: 'foo' })
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', sscDomain: 'foo', useServerSideCookie: true, })
       expect(td.client.cookieDomain).to.be('foo')
     })
     it('should support cookieDomain as function', function () {
       var foo = function () { return 'foo' }
       var cookieDomainHost = function (host) { return ['ssc', foo] }
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: foo, cookieDomainHost: cookieDomainHost })
-      expect(td.client.cookieDomain).to.be(foo)
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', useServerSideCookie: true, sscDomain: foo, sscServer: cookieDomainHost })
+      expect(td.client.sscDomain).to.be(foo)
       // we need to set cookie to prevent the real jsonp going out
       cookie.setItem('td_ssc_id', 'foo')
       expect(td._serverCookieDomain).to.be('foo')
@@ -29,7 +29,7 @@ describe('Treasure Server Cookie', function () {
       cookie.setItem('td_ssc_id', 'foo')
     })
     it('should return td_ssc_id from cookie if available', function (done) {
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey' })
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', useServerSideCookie: true })
       td.fetchServerCookie(function (val) {
         expect(val).to.be('foo')
         done()

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -4,11 +4,11 @@ var cookie = require('../lib/vendor/js-cookies')
 
 describe('Treasure Server Cookie', function () {
   describe('configure', () => {
-    it('should support cookieDomain as string', () => {
+    it('should support cookieDomain as string', function () {
       var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: 'foo' })
       expect(td.client.cookieDomain).to.be('foo')
     })
-    it('should support cookieDomain as function', () => {
+    it('should support cookieDomain as function', function () {
       var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: () => 'foo' })
       expect(td.client.cookieDomain).to.be('foo')
     })

--- a/test/treasure.servercookie.js
+++ b/test/treasure.servercookie.js
@@ -10,8 +10,13 @@ describe('Treasure Server Cookie', function () {
     })
     it('should support cookieDomain as function', function () {
       var foo = function () { return 'foo' }
-      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: foo })
+      var cookieDomainHost = function (host) { return ['ssc', foo] }
+      var td = new Treasure({ database: 'foo', writeKey: 'writeKey', cookieDomain: foo, cookieDomainHost: cookieDomainHost })
       expect(td.client.cookieDomain).to.be(foo)
+      // we need to set cookie to prevent the real jsonp going out
+      cookie.setItem('td_ssc_id', 'foo')
+      expect(td._serverCookieDomain).to.be('foo')
+      expect(td._serverCookieDomainHost).to.be('ssc.foo')
     })
   })
   it('adds fetchServerCookie method', function () {


### PR DESCRIPTION
Adds support for Server side cookie tracking rather than client side

TODO:
- [x] test implementation
- [x] document feature in readme