### PR TITLE
Fix typo: `a a` => `a`

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -151,7 +151,7 @@ exports._sendRecord = function _sendRecord (request, success, error) {
 /**
  * Treasure#applyProperties
  *
- * Applies properties on a a payload object
+ * Applies properties on a payload object
  *
  * Starts with an empty object and applies properties in the following order:
  * $global -> table -> payload


### PR DESCRIPTION
I just found a typo and fixed it.