### PR TITLE
Add fetchWithTimeout functionality

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -5,6 +5,7 @@
 // Modules
 var invariant = require('./utils/misc').invariant
 var noop = require('./utils/misc').noop
+var fetchWithTimeout = require('./utils/misc').fetchWithTimeout
 var jsonp = require('jsonp')
 var _ = require('./utils/lodash')
 var global = require('global')
@@ -137,7 +138,7 @@ exports._sendRecord = function _sendRecord (request, success, error) {
   var isClickedLink = request.record.tag === 'a' && !!request.record.href
 
   if (window.fetch && (this._windowBeingUnloaded || isClickedLink)) {
-    window.fetch(url, {
+    fetchWithTimeout(url, this.client.jsonpTimeout, {
       method: 'POST',
       keepalive: true
     })

--- a/lib/utils/misc.js
+++ b/lib/utils/misc.js
@@ -16,8 +16,33 @@ function invariant (conditon, text) {
 
 function noop () {}
 
+function _timeout (milliseconds, promise, timeoutMessage) {
+  var timerPromise = new Promise(function (resolve, reject) {
+    setTimeout(function () {
+      reject(new Error(timeoutMessage || 'Operation Timeout'))
+    }, milliseconds)
+  })
+  return Promise.race([timerPromise, promise])
+}
+
+function fetchWithTimeout (url, milliseconds, options) {
+  if (window.AbortController) {
+    var controller = new window.AbortController()
+    var promise = window.fetch(url, Object.assign({}, options, {signal: controller.signal}))
+    var timeoutId = setTimeout(function () {
+      controller.abort()
+    }, milliseconds)
+    return promise['finally'](function () {
+      clearTimeout(timeoutId)
+    })
+  } else {
+    return _timeout(milliseconds, window.fetch(url, options), 'Request Timeout')
+  }
+}
+
 module.exports = {
   disposable: disposable,
   invariant: invariant,
-  noop: noop
+  noop: noop,
+  fetchWithTimeout: fetchWithTimeout
 }


### PR DESCRIPTION
In case user use SPA/PWA, td-js-sdk would need a way to timeout request. The strategy is simple:
- Use AbortController to abort request
- In case browser does not support for AbortController, use good old setTimeout