### PR TITLE
Fixed the types of `sscDomain` and `sscServer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ If the database does not exist and you have permissions, it will be created for 
 
 **Server Side Cookie:**
 * **config.useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie - Default False
-* **config.sscDomain** : String | () => String (optional) - Domain against which the Server Side Cokkie is set Default: `window.location.hostname`
+* **config.sscDomain** : String | () => String (optional) - Domain against which the Server Side Cookie is set Default: `window.location.hostname`
 * **config.sscServer** : String | (String) => String (optional) - hostname to request server side cookie from Default `ssc.${sscDomain}`
 
 

--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ If the database does not exist and you have permissions, it will be created for 
 
 **Server Side Cookie:**
 * **config.useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie - Default False
-* **config.sscDomain** : String | (String) => String (optional) - Domain against which the Server Side Cokkie is set Default: `window.location.hostname`
-* **config.sscServer** : String (optional) - hostname to request server side cookie from Default `ssc.${sscDomain}`
+* **config.sscDomain** : String | () => String (optional) - Domain against which the Server Side Cokkie is set Default: `window.location.hostname`
+* **config.sscServer** : String | (String) => String (optional) - hostname to request server side cookie from Default `ssc.${sscDomain}`
 
 
 **Personalization parameters**

--- a/README.md
+++ b/README.md
@@ -318,9 +318,9 @@ If the database does not exist and you have permissions, it will be created for 
 * **config.storage.domain** : String (optional) - cookie domain. Default: result of `document.location.hostname`
 
 **Server Side Cookie:**
-* **config.useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie - Default False
-* **config.sscDomain** : String | () => String (optional) - Domain against which the Server Side Cookie is set Default: `window.location.hostname`
-* **config.sscServer** : String | (String) => String (optional) - hostname to request server side cookie from Default `ssc.${sscDomain}`
+* **config.useServerSideCookie** : Boolean (optional) - enables/disable using ServerSide Cookie. Default: `false`
+* **config.sscDomain** : String | () => String (optional) - Domain against which the Server Side Cookie is set. Default: `window.location.hostname`
+* **config.sscServer** : String | (String) => String (optional) - hostname to request server side cookie from. Default: `ssc.${sscDomain}`
 
 
 **Personalization parameters**


### PR DESCRIPTION
With this pull request I fixed the types of `sscDomain` and `sscServer`.

In the current README, the type of `sscDomain` is `string` or `(string) => string`, but [according to the code in servercookie.js](https://github.com/treasure-data/td-js-sdk/blob/ad2a2c6099cb1ec6b0989b01372a77f36157b286/lib/plugins/servercookie.js#L27), `sscDomain` takes no arguments.

Also, the type of `sscServer` is described as `string`, but [looking at the code](https://github.com/treasure-data/td-js-sdk/blob/ad2a2c6099cb1ec6b0989b01372a77f36157b286/lib/plugins/servercookie.js#L31-L35), `string | (string) => string` would be more appropriate.