### PR TITLE
Guard deprecated platform property

### DIFF
--- a/lib/plugins/track.js
+++ b/lib/plugins/track.js
@@ -70,7 +70,9 @@ function configureValues (track) {
         return [userAgent, sdkUserAgent].join(';')
       },
       td_platform: function () {
-        return window.navigator.platform
+        // navigator.platform is recommended to using another way because of deprecated.
+        // Use navigator.userAgentData.platform instead.
+        return window.navigator.platform || window.navigator.userAgentData.platform
       },
       td_host: function () {
         return document.location.host


### PR DESCRIPTION
I propose to introduce a property to guard `td_platform` value.
Currently, `td_platform` is based on `window.navigator.platform`. However, this property is not recommended now:

> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform#browser_compatibility) at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform

So that I want to introduce a platform property of NavigatorUAData: `window.navigator.userAgentData.platform`.
https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform

This property changes a value "MacIntel" (M1, M2 Mac is recognized as "MacIntel"!) to "macOS", for example.
However, existing behavior is prioritized because the `window.navigator.userAgentData.platform` has been experimental yet and browser compatibility is so restricted.

What do you think about it?