### PR TITLE
Enable global id only when in signed mode

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -200,7 +200,7 @@ exports._sendRecord = function _sendRecord (request, success, error, blockedEven
     requestHeaders['Authorization'] = 'TD1 ' + request.apikey
     requestHeaders['User-Agent'] = navigator.userAgent
 
-    if (this.isGlobalIdEnabled()) {
+    if (this.inSignedMode() && this.isGlobalIdEnabled()) {
       requestHeaders['Content-Type'] = misc.globalIdAdlHeaders['Content-Type']
       requestHeaders['Accept'] = misc.globalIdAdlHeaders['Accept']
     } else {


### PR DESCRIPTION
### Issue
Enabling cross domain tracking with `td.set('$global', 'td_global_id', 'td_global_id')` causes  cause td_global_id and td_ip to be recorded even in anonymous mode

### Fix
Only record `td_global_id` and `td_ip` when in signed mode.