### PR TITLE
INTEG-4908: Add Yahoo Japan measurement tag support (_ly_c, _ly_r, _ly_su)

### DIFF
--- a/lib/plugins/conversion_api_support.js
+++ b/lib/plugins/conversion_api_support.js
@@ -138,6 +138,30 @@ var getYahoo_yjsu_yjad_Cookie = function () {
   }
 }
 
+var getYahoo_ly_c_Param = function () {
+  return {
+    ly_c: getParam('_ly_c')
+  }
+}
+
+var getYahoo_ly_c_Cookie = function () {
+  return {
+    ly_c: getCookie('_ly_c')
+  }
+}
+
+var getYahoo_ly_r_Cookie = function () {
+  return {
+    ly_r: getCookie('_ly_r')
+  }
+}
+
+var getYahoo_ly_su_Cookie = function () {
+  return {
+    ly_su: getCookie('_ly_su')
+  }
+}
+
 // Line
 var getLine_lt_cid_Cookie = function () {
   return {
@@ -228,6 +252,10 @@ var API = {
   getYahoo_ycl_yjad_Cookie,
   getYahoo_yjr_yjad_Cookie,
   getYahoo_yjsu_yjad_Cookie,
+  getYahoo_ly_c_Param,
+  getYahoo_ly_c_Cookie,
+  getYahoo_ly_r_Cookie,
+  getYahoo_ly_su_Cookie,
   getLine_lt_cid_Cookie,
   getLine_lt_sid_Cookie,
   getLine_ldtag_cl_Param,
@@ -257,6 +285,10 @@ var vendorFunctionMappings = {
     'getInstagram_ig_did_Cookie'
   ],
   yahoojp_ads: [
+    'getYahoo_ly_c_Param',
+    'getYahoo_ly_c_Cookie',
+    'getYahoo_ly_r_Cookie',
+    'getYahoo_ly_su_Cookie',
     'getYahoo_yclid_Param',
     'getYahoo_yj_r_Param',
     'getYahoo_ycl_yjad_Cookie',

--- a/test/treasure.fetch_cookies.spec.js
+++ b/test/treasure.fetch_cookies.spec.js
@@ -33,6 +33,18 @@ function setInstagramCookies() {
   cookies.setItem('ds_user_id', 'anuid', 5)
 }
 
+function setYahooJapanMeasurementCookies() {
+  cookies.setItem('_ly_c', 'ly_c_value', 5)
+  cookies.setItem('_ly_r', 'ly_r_value', 5)
+  cookies.setItem('_ly_su', 'ly_su_value', 5)
+}
+
+function setYahooJapanLegacyCookies() {
+  cookies.setItem('_ycl_yjad', 'ycl_value', 5)
+  cookies.setItem('_yjr_yjad', 'yjr_value', 5)
+  cookies.setItem('_yjsu_yjad', 'yjsu_value', 5)
+}
+
 function setTestCookies() {
   cookies.setItem(cookieA, 'a', 5)
   cookies.setItem(cookieB, 'b', 5)
@@ -178,6 +190,101 @@ describe('Fetch cookies and params', function () {
       expect(globalTable['shbts']).to.equal('shbts')
       expect(globalTable['shbid']).to.equal('shbid')
       expect(globalTable['ds_user_id']).to.equal('anuid')
+    })
+  })
+
+  describe('#collectTags Yahoo Japan measurement tags', function () {
+    beforeEach(function () {
+      treasure = new Treasure(configs)
+    })
+
+    it('should collect _ly_c, _ly_r, _ly_su cookies with underscore removed', function () {
+      setYahooJapanMeasurementCookies()
+
+      treasure.collectTags({
+        vendors: ['yahoojp_ads']
+      })
+
+      var globalTable = treasure.get('$global')
+
+      expect(globalTable['ly_c']).to.equal('ly_c_value')
+      expect(globalTable['ly_r']).to.equal('ly_r_value')
+      expect(globalTable['ly_su']).to.equal('ly_su_value')
+    })
+
+    it('should collect _ly_c from URL parameter when cookie is missing', function () {
+      // Mock window.location.search
+      var originalLocation = window.location
+      delete window.location
+      window.location = { search: '?_ly_c=param_value' }
+
+      treasure.collectTags({
+        vendors: ['yahoojp_ads']
+      })
+
+      var globalTable = treasure.get('$global')
+
+      expect(globalTable['ly_c']).to.equal('param_value')
+
+      // Restore
+      window.location = originalLocation
+    })
+
+    it('should prioritize cookie over parameter for _ly_c', function () {
+      // Set cookie
+      cookies.setItem('_ly_c', 'cookie_value', 5)
+
+      // Mock URL parameter
+      var originalLocation = window.location
+      delete window.location
+      window.location = { search: '?_ly_c=param_value' }
+
+      treasure.collectTags({
+        vendors: ['yahoojp_ads']
+      })
+
+      var globalTable = treasure.get('$global')
+
+      // Cookie should override parameter
+      expect(globalTable['ly_c']).to.equal('cookie_value')
+
+      // Restore
+      window.location = originalLocation
+    })
+
+    it('should maintain backward compatibility with existing Yahoo tags', function () {
+      setYahooJapanLegacyCookies()
+
+      treasure.collectTags({
+        vendors: ['yahoojp_ads']
+      })
+
+      var globalTable = treasure.get('$global')
+
+      expect(globalTable['_ycl_yjad']).to.equal('ycl_value')
+      expect(globalTable['_yjr_yjad']).to.equal('yjr_value')
+      expect(globalTable['_yjsu_yjad']).to.equal('yjsu_value')
+    })
+
+    it('should collect both new and legacy Yahoo tags together', function () {
+      setYahooJapanMeasurementCookies()
+      setYahooJapanLegacyCookies()
+
+      treasure.collectTags({
+        vendors: ['yahoojp_ads']
+      })
+
+      var globalTable = treasure.get('$global')
+
+      // New measurement tags (without underscore)
+      expect(globalTable['ly_c']).to.equal('ly_c_value')
+      expect(globalTable['ly_r']).to.equal('ly_r_value')
+      expect(globalTable['ly_su']).to.equal('ly_su_value')
+
+      // Legacy tags (with underscore)
+      expect(globalTable['_ycl_yjad']).to.equal('ycl_value')
+      expect(globalTable['_yjr_yjad']).to.equal('yjr_value')
+      expect(globalTable['_yjsu_yjad']).to.equal('yjsu_value')
     })
   })
 })


### PR DESCRIPTION
## Overview

Extends Yahoo Japan tag support to collect additional measurement tag cookies (`_ly_c`, `_ly_r`, `_ly_su`) while maintaining full backward compatibility.

## Changes

### New Features
- Add support for Yahoo Japan measurement tag cookies: `_ly_c`, `_ly_r`, `_ly_su`
- Support `_ly_c` as both cookie and URL parameter (cookie takes priority)
- Store keys without leading underscore (`ly_c`, `ly_r`, `ly_su`)

### Implementation Details
- Added 4 new getter functions in `lib/plugins/conversion_api_support.js`
- Registered getters in API object and `yahoojp_ads` vendor mapping
- Cookie priority over parameter implemented via `Object.assign` merge order

### Backward Compatibility
- ✅ All existing Yahoo Japan tags continue to work
- ✅ No changes to `collectTags()` public API
- ✅ No breaking changes

### Testing
- Added 5 comprehensive test cases in `test/treasure.fetch_cookies.spec.js`
- Tests cover: cookie collection, parameter fallback, priority rules, backward compatibility

## Tag Mapping

| Cookie/Parameter | Stored Key | Type | Priority |
|-----------------|------------|------|----------|
| `_ly_c` (cookie) | `ly_c` | Cookie | High |
| `_ly_c` (param) | `ly_c` | URL Param | Low (fallback) |
| `_ly_r` | `ly_r` | Cookie | - |
| `_ly_su` | `ly_su` | Cookie | - |

## Usage

```javascript
var td = new Treasure({ /* config */ })
td.collectTags({ vendors: ["yahoojp_ads"] })

// Collected tags:
// {
//   ly_c: "...",         // NEW
//   ly_r: "...",         // NEW
//   ly_su: "...",        // NEW
//   yclid: "...",        // EXISTING
//   yj_r: "...",         // EXISTING
//   _ycl_yjad: "...",    // EXISTING
//   _yjr_yjad: "...",    // EXISTING
//   _yjsu_yjad: "..."    // EXISTING
// }
```

## Related

Extends the Yahoo Japan support added in commit 61d78027248c187ddfaa49e632105e8d993dc5e1